### PR TITLE
fake clock: track early risers

### DIFF
--- a/campaign_test.go
+++ b/campaign_test.go
@@ -469,10 +469,9 @@ func TestAcquireAndReplaceWithFakeClockAndSkew(t *testing.T) {
 	// now, advance all the way to the end of the term according to the
 	// second candidate (the second candidate should still be sleeping
 	// anyway)
-	// However, the lock-holder was supposed to wake up to refresh its
-	// lease.
-	if awoken := fc.Advance(time.Microsecond); awoken != 1 {
-		t.Errorf("too many sleepers awoken %d; wanted 1", awoken)
+	// no one should awaken since the original lock holder had its context cancelled.
+	if awoken := fc.Advance(time.Microsecond); awoken != 0 {
+		t.Errorf("too many sleepers awoken %d; wanted 0", awoken)
 	}
 	// In this test, the max clock-skew exactly matches the skew for our
 	// second candidate, so we should still need another second in


### PR DESCRIPTION
Explicitly remove sleepers' entries from the sleepers map when they
exit, so context cancellation doesn't lead to a large growth in the
number of sleepers. (which makes tests rather confusing)

Adjust the one test that seemed to care.