### PR TITLE
Remove HostPort length check

### DIFF
--- a/campaign.go
+++ b/campaign.go
@@ -38,9 +38,6 @@ func (c Config) Acquire(ctx context.Context) error {
 	if c.LeaderID == "" {
 		return fmt.Errorf("missing LeaderID")
 	}
-	if len(c.HostPort) < 1 {
-		return fmt.Errorf("missing HostPort")
-	}
 
 	// Note that this method has a non-pointer receiver so we get a private
 	// copy for use with the other methods, thus avoiding possible races

--- a/campaign_test.go
+++ b/campaign_test.go
@@ -578,7 +578,7 @@ func TestMultipleContendersWithFakeClockAndSkew(t *testing.T) {
 					contenders[lz].oustingCh <- struct{}{}
 				},
 				LeaderID:         "maybeLeader" + strconv.Itoa(lz),
-				HostPort:         []string{"127.0.0.2:" + strconv.Itoa(7123+lz)},
+				HostPort:         nil,
 				Decider:          d,
 				TermLength:       termLength,
 				ConnectionParams: []byte("bimbat" + strconv.Itoa(lz)),

--- a/leaderelection.go
+++ b/leaderelection.go
@@ -90,7 +90,11 @@ type Config struct {
 	LeaderChanged func(ctx context.Context, entry entry.RaceEntry)
 
 	LeaderID string
+
 	// HostPort is a slice of the system's unicast interface addresses to which clients should connect.
+	// Optional, but recommended in general.
+	// Required if used in combination with legrpc, so the RaceDecider has
+	// a record of how to connect to the current leader.
 	HostPort []string
 
 	// Decider is the RaceDecider implementation in use


### PR DESCRIPTION
There are many use-cases where there won't be a port open, drop the
requirement.


(note: this PR is the first of four)