### PR TITLE
Added support to create TimeView with a defined expiration

### DIFF
--- a/leaderelection.go
+++ b/leaderelection.go
@@ -42,12 +42,19 @@ func NewTimeView(c clocks.Clock) *TimeView {
 		c = clocks.DefaultClock()
 	}
 	now := c.Now()
+	return NewTimeViewWithExpiration(c, now)
+}
+
+// NewTimeViewWithExpiration constructs a TimeView with a defined expiration time
+func NewTimeViewWithExpiration(c clocks.Clock, expirationTime time.Time) *TimeView {
+	if c == nil {
+		c = clocks.DefaultClock()
+	}
 	tv := TimeView{
 		clock: c,
 	}
-	tv.Set(now)
+	tv.Set(expirationTime)
 	return &tv
-
 }
 
 // Clock returns the clocks.Clock instance against-which times are measured.

--- a/leaderelection.go
+++ b/leaderelection.go
@@ -41,19 +41,18 @@ func NewTimeView(c clocks.Clock) *TimeView {
 	if c == nil {
 		c = clocks.DefaultClock()
 	}
-	now := c.Now()
-	return NewTimeViewWithExpiration(c, now)
+	return NewTimeViewWithExpiration(c, time.Duration(0))
 }
 
 // NewTimeViewWithExpiration constructs a TimeView with a defined expiration time
-func NewTimeViewWithExpiration(c clocks.Clock, expirationTime time.Time) *TimeView {
+func NewTimeViewWithExpiration(c clocks.Clock, expirationTime time.Duration) *TimeView {
 	if c == nil {
 		c = clocks.DefaultClock()
 	}
 	tv := TimeView{
 		clock: c,
 	}
-	tv.Set(expirationTime)
+	tv.Set(c.Now().Add(expirationTime))
 	return &tv
 }
 


### PR DESCRIPTION
The default NewTimeView sets the expiration time to `time.Now()` from the provided clock. This caused the TimeView to immediately return `ValueInFuture()` as `false` which could affect any logic that relied on the current leader. This is especially true when testing. By adding `NewTimeViewWithExpiration` you can now specify the expiration `time.Time` when creating the TimeView. 